### PR TITLE
Fix duplicate patient ID outputs

### DIFF
--- a/bin/generate_cbioPortal_files.py
+++ b/bin/generate_cbioPortal_files.py
@@ -268,12 +268,15 @@ def generate_portal_data_clinical_patient(clinical_data):
     list
         a list of dict's subset for just the keys used in the data_clinical_patient.txt file
     """
+    patient_ids = {} # use this dict to prevent duplicate patient IDs from being emitted
     clinical_patient_data = []
     for row in clinical_data:
-        new_row = {}
-        new_row['PATIENT_ID'] = row['PATIENT_ID']
-        new_row['SEX'] = row['SEX']
-        clinical_patient_data.append(new_row)
+        if row['PATIENT_ID'] not in patient_ids:
+            new_row = {}
+            new_row['PATIENT_ID'] = row['PATIENT_ID']
+            new_row['SEX'] = row['SEX']
+            clinical_patient_data.append(new_row)
+            patient_ids[row['PATIENT_ID']] = ''
     return(clinical_patient_data)
 
 def generate_portal_data_clinical_sample(clinical_data):

--- a/tests/test_generate_cbioPortal_files.py
+++ b/tests/test_generate_cbioPortal_files.py
@@ -90,6 +90,23 @@ class TestGenerateCBioFiles(unittest.TestCase):
         ]
         self.assertEqual(clinical_patient_data, expected_data)
 
+    def test_generate_portal_data_clinical_patient_dupes(self):
+        """
+        Test that clinical patient data is generated correctly
+        There should be no duplicate PATIENT_ID's in the output even if the input has duplicates
+        """
+        clinical_data = [
+        {'PATIENT_ID': 'Patient1', 'SEX': 'M', 'foo': 'bar', 'baz': 'buzz'},
+        {'PATIENT_ID': 'Patient1', 'SEX': 'M', 'foo': 'bar', 'baz': 'buzz'},
+        {'PATIENT_ID': 'Patient2', 'SEX': 'F', 'foo': 'bar1', 'baz': 'buzz1'}
+        ]
+        clinical_patient_data = generate_portal_data_clinical_patient(clinical_data)
+        expected_data = [
+        {'PATIENT_ID': 'Patient1', 'SEX': 'M'},
+        {'PATIENT_ID': 'Patient2', 'SEX': 'F'}
+        ]
+        self.assertEqual(clinical_patient_data, expected_data)
+
     def test_generate_portal_data_clinical_sample(self):
         """
         Test that clinical patient data is generated correctly


### PR DESCRIPTION
Duplicate patient ID's were being output in the `data_clinical_patient.txt`, fixed it 

fixes #22